### PR TITLE
Add abstraction layer for external Java tools

### DIFF
--- a/docs/plan-claude.md
+++ b/docs/plan-claude.md
@@ -1,0 +1,161 @@
+# Strategic Testing Plan for jb
+
+## Overview
+
+For a build tool to be fun to use, it needs to be very thoroughly tested and provide great error reporting. This document outlines a comprehensive strategy for improving jb's testing infrastructure, error handling, and cross-platform reliability.
+
+## Current State
+- Limited unit tests (only in `builder` and `maven` packages)
+- Integration tests exist but are basic (in `tests/` directory)
+- No cross-platform testing
+- No JDK version matrix testing
+- Limited error handling and reporting
+
+## Key Challenges
+1. **External Dependencies**: javac, jar, java, Maven repositories
+2. **Platform Variations**: Path handling, file separators, executable extensions
+3. **JDK Version Differences**: Different flags, behaviors, and features across Java 8, 11, 17, 21, etc.
+4. **Error Messaging**: Need to translate cryptic javac errors into helpful guidance
+
+## Recommended Strategy
+
+### 1. Testing Architecture
+```
+jb/
+├── internal_test/     # Unit tests with mocks
+├── integration/       # Integration test suite (separate module)
+│   ├── fixtures/      # Test projects
+│   ├── scenarios/     # Test scenarios
+│   └── matrix/        # Platform/JDK specific tests
+└── .github/
+    └── workflows/     # CI/CD matrix testing
+```
+
+**Rationale**: Keep integration tests as a subfolder rather than separate repo to:
+- Maintain version synchronization
+- Simplify contribution process
+- Enable atomic commits that include both code and test changes
+
+### 2. Abstraction Layer for External Tools
+
+Create interfaces for external tool interaction:
+
+```go
+type JavaCompiler interface {
+    Compile(args CompileArgs) (CompileResult, error)
+    Version() (JavaVersion, error)
+}
+
+type JarTool interface {
+    Create(args JarArgs) error
+    Extract(jar, dest string) error
+    List(jar string) ([]string, error)
+}
+
+type JavaRunner interface {
+    Run(args RunArgs) error
+    Version() (JavaVersion, error)
+}
+```
+
+This enables:
+- Unit testing with mocks
+- Platform-specific implementations
+- Better error handling and normalization
+- Version-specific behavior handling
+
+### 3. Error Reporting Framework
+
+Implement a diagnostic system that:
+- Parses javac output and provides helpful suggestions
+- Detects common issues (missing dependencies, wrong JDK version)
+- Provides contextual help based on the error type
+- Shows progress indicators for long operations
+- Supports different verbosity levels
+
+Example error transformation:
+```
+Before: "error: cannot find symbol"
+After:  "Cannot find class 'ArrayList'. Did you forget to import java.util.ArrayList?"
+```
+
+### 4. CI/CD Matrix Strategy
+
+Start with GitHub Actions matrix:
+```yaml
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest, macos-latest]
+    java: [8, 11, 17, 21]  # LTS versions
+```
+
+### 5. Phased Implementation Plan
+
+#### Completed Work
+
+**Abstraction Layer (December 2024)**
+- Created `tools` package with interfaces for JavaCompiler, JarTool, JavaRunner, and ToolProvider
+- Implemented default implementations that wrap system commands
+- Added mock implementations for testing
+- Updated Java builder to use abstractions instead of direct exec.Command calls
+- Improved error handling with structured CompileResult containing parsed errors/warnings
+- Added platform-specific helpers and JDK detection
+- All existing tests pass with the new implementation
+
+#### Phase 1: Foundation (2-3 weeks)
+- ✅ Create abstraction interfaces for external tools (COMPLETED)
+- Implement error reporting framework
+- Add comprehensive unit tests for existing code
+- Set up basic CI/CD pipeline
+
+#### Phase 2: Integration Testing (3-4 weeks)
+- Design integration test framework
+- Create test fixtures for various project types
+- Implement JDK version detection and compatibility
+- Add Windows/Linux/macOS specific tests
+
+#### Phase 3: Enhanced Diagnostics (2-3 weeks)
+- Implement javac error parser
+- Add helpful error messages and suggestions
+- Create progress indicators
+- Add verbose/debug logging options
+
+#### Phase 4: Advanced Features (ongoing)
+- Parallel builds
+- Incremental compilation
+- Build caching
+- Performance profiling
+
+## Immediate Next Steps
+
+1. ✅ **Create the abstraction layer** - This unblocks both unit testing and cross-platform support (COMPLETED)
+2. **Set up GitHub Actions** with a basic matrix for the current tests
+3. **Implement error reporting framework** - Start capturing and improving error messages
+4. **Add unit tests** for the existing packages using the new abstractions
+
+## Key Design Decisions
+
+1. **Integration tests in subfolder** - Easier to maintain and coordinate
+2. **Start with LTS Java versions** - Cover 8, 11, 17, 21 initially
+3. **Use GitHub Actions** - Free for open source, good matrix support
+4. **Mock external tools for unit tests** - But integration tests use real tools
+5. **Error messages as first-class feature** - Not an afterthought
+
+## Success Metrics
+
+- Unit test coverage > 80%
+- Integration tests pass on all supported platforms
+- Error messages provide actionable guidance
+- Build times remain fast (< 1s for small projects)
+- Zero platform-specific bugs in common scenarios
+
+## Long-term Vision
+
+jb should be the most reliable and user-friendly Java build tool, with:
+- Excellent error messages that guide users to solutions
+- Rock-solid cross-platform support
+- Fast builds that "just work"
+- Comprehensive test coverage ensuring stability
+- Clear documentation and helpful diagnostics
+
+This approach balances immediate needs (better testing) with long-term goals (cross-platform reliability) while keeping the tool's simplicity philosophy intact.

--- a/tools/default_compiler.go
+++ b/tools/default_compiler.go
@@ -1,0 +1,270 @@
+package tools
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// DefaultJavaCompiler implements JavaCompiler using the system javac command
+type DefaultJavaCompiler struct {
+	javacPath string
+	version   *JavaVersion
+}
+
+// NewDefaultJavaCompiler creates a new DefaultJavaCompiler
+func NewDefaultJavaCompiler() *DefaultJavaCompiler {
+	return &DefaultJavaCompiler{}
+}
+
+// Compile compiles Java source files
+func (c *DefaultJavaCompiler) Compile(args CompileArgs) (CompileResult, error) {
+	result := CompileResult{
+		Success: true,
+		Errors:  []CompileError{},
+		Warnings: []CompileWarning{},
+	}
+
+	// Ensure javac is available
+	if !c.IsAvailable() {
+		return result, fmt.Errorf("javac not found in PATH")
+	}
+
+	// Create temporary files for arguments to avoid command line length limits
+	tmpDir := os.TempDir()
+	
+	// Write compiler flags to file
+	flagsFile := filepath.Join(tmpDir, fmt.Sprintf("jb-javac-flags-%d.txt", os.Getpid()))
+	defer os.Remove(flagsFile)
+	
+	var flags []string
+	flags = append(flags, "-d", args.DestDir)
+	
+	if args.ClassPath != "" {
+		flags = append(flags, "-cp", args.ClassPath)
+	}
+	
+	if args.SourceVersion != "" {
+		flags = append(flags, "-source", args.SourceVersion)
+	}
+	
+	if args.TargetVersion != "" {
+		flags = append(flags, "-target", args.TargetVersion)
+	}
+	
+	flags = append(flags, args.ExtraFlags...)
+	
+	flagsContent := strings.Join(flags, "\n")
+	if err := os.WriteFile(flagsFile, []byte(flagsContent), 0644); err != nil {
+		return result, fmt.Errorf("failed to write flags file: %w", err)
+	}
+	
+	// Write source files list
+	sourcesFile := filepath.Join(tmpDir, fmt.Sprintf("jb-javac-sources-%d.txt", os.Getpid()))
+	defer os.Remove(sourcesFile)
+	
+	sourcesContent := strings.Join(args.SourceFiles, "\n")
+	if err := os.WriteFile(sourcesFile, []byte(sourcesContent), 0644); err != nil {
+		return result, fmt.Errorf("failed to write sources file: %w", err)
+	}
+	
+	// Execute javac
+	cmd := exec.Command(c.javacPath, "@"+flagsFile, "@"+sourcesFile)
+	if args.WorkDir != "" {
+		cmd.Dir = args.WorkDir
+	}
+	
+	// Capture output
+	output, err := cmd.CombinedOutput()
+	result.RawOutput = string(output)
+	
+	// Parse output for errors and warnings
+	c.parseCompilerOutput(result.RawOutput, &result)
+	
+	if err != nil {
+		result.Success = false
+		if result.ErrorCount == 0 && len(result.Errors) == 0 {
+			// If we couldn't parse any errors, create a generic one
+			result.Errors = append(result.Errors, CompileError{
+				Message: fmt.Sprintf("compilation failed: %v", err),
+			})
+			result.ErrorCount = 1
+		}
+	}
+	
+	return result, nil
+}
+
+// parseCompilerOutput parses javac output for errors and warnings
+func (c *DefaultJavaCompiler) parseCompilerOutput(output string, result *CompileResult) {
+	// Regex patterns for different javac error formats
+	// Format: filename.java:line: error: message
+	errorPattern := regexp.MustCompile(`^(.+?):(\d+):\s*(error|warning):\s*(.+)$`)
+	// Format: filename.java:line:column: error: message (newer javac versions)
+	errorPatternWithColumn := regexp.MustCompile(`^(.+?):(\d+):(\d+):\s*(error|warning):\s*(.+)$`)
+	
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	var currentError *CompileError
+	var currentWarning *CompileWarning
+	
+	for scanner.Scan() {
+		line := scanner.Text()
+		
+		// Try to match error/warning patterns
+		if matches := errorPatternWithColumn.FindStringSubmatch(line); len(matches) > 0 {
+			file := matches[1]
+			lineNum, _ := strconv.Atoi(matches[2])
+			column, _ := strconv.Atoi(matches[3])
+			errorType := matches[4]
+			message := matches[5]
+			
+			if errorType == "error" {
+				currentError = &CompileError{
+					File:    file,
+					Line:    lineNum,
+					Column:  column,
+					Message: message,
+				}
+				result.Errors = append(result.Errors, *currentError)
+				result.ErrorCount++
+			} else {
+				currentWarning = &CompileWarning{
+					File:    file,
+					Line:    lineNum,
+					Column:  column,
+					Message: message,
+				}
+				result.Warnings = append(result.Warnings, *currentWarning)
+				result.WarningCount++
+			}
+		} else if matches := errorPattern.FindStringSubmatch(line); len(matches) > 0 {
+			file := matches[1]
+			lineNum, _ := strconv.Atoi(matches[2])
+			errorType := matches[3]
+			message := matches[4]
+			
+			if errorType == "error" {
+				currentError = &CompileError{
+					File:    file,
+					Line:    lineNum,
+					Message: message,
+				}
+				result.Errors = append(result.Errors, *currentError)
+				result.ErrorCount++
+			} else {
+				currentWarning = &CompileWarning{
+					File:    file,
+					Line:    lineNum,
+					Message: message,
+				}
+				result.Warnings = append(result.Warnings, *currentWarning)
+				result.WarningCount++
+			}
+		} else if strings.Contains(line, "error") && currentError != nil {
+			// Continuation of error message
+			currentError.Message += "\n" + line
+		} else if strings.Contains(line, "warning") && currentWarning != nil {
+			// Continuation of warning message
+			currentWarning.Message += "\n" + line
+		}
+	}
+	
+	// Check for summary line (e.g., "2 errors")
+	summaryPattern := regexp.MustCompile(`^(\d+)\s+errors?$`)
+	if matches := summaryPattern.FindStringSubmatch(strings.TrimSpace(output)); len(matches) > 0 {
+		count, _ := strconv.Atoi(matches[1])
+		if count > result.ErrorCount {
+			result.ErrorCount = count
+		}
+	}
+}
+
+// Version returns the compiler version information
+func (c *DefaultJavaCompiler) Version() (JavaVersion, error) {
+	if c.version != nil {
+		return *c.version, nil
+	}
+	
+	if !c.IsAvailable() {
+		return JavaVersion{}, fmt.Errorf("javac not found")
+	}
+	
+	cmd := exec.Command(c.javacPath, "-version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return JavaVersion{}, fmt.Errorf("failed to get javac version: %w", err)
+	}
+	
+	version := parseJavaVersion(string(output))
+	c.version = &version
+	return version, nil
+}
+
+// IsAvailable checks if the compiler is available on the system
+func (c *DefaultJavaCompiler) IsAvailable() bool {
+	if c.javacPath != "" {
+		return true
+	}
+	
+	// Try to find javac
+	path, err := exec.LookPath("javac")
+	if err != nil {
+		return false
+	}
+	
+	c.javacPath = path
+	return true
+}
+
+// parseJavaVersion parses version output from Java tools
+func parseJavaVersion(output string) JavaVersion {
+	version := JavaVersion{
+		Full: strings.TrimSpace(output),
+	}
+	
+	// Try different version patterns
+	// Pattern 1: javac 1.8.0_292 (older format)
+	// Pattern 2: javac 11.0.11 (newer format)
+	// Pattern 3: javac 17 (even newer format)
+	
+	versionPattern := regexp.MustCompile(`(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
+	if matches := versionPattern.FindStringSubmatch(output); len(matches) > 0 {
+		version.Major, _ = strconv.Atoi(matches[1])
+		if len(matches) > 2 && matches[2] != "" {
+			version.Minor, _ = strconv.Atoi(matches[2])
+		}
+		if len(matches) > 3 && matches[3] != "" {
+			version.Patch, _ = strconv.Atoi(matches[3])
+		}
+		
+		// Handle old version format (1.x -> x)
+		if version.Major == 1 && version.Minor > 0 {
+			version.Major = version.Minor
+			version.Minor = 0
+		}
+	}
+	
+	// Detect vendor
+	lowerOutput := strings.ToLower(output)
+	switch {
+	case strings.Contains(lowerOutput, "openjdk"):
+		version.Vendor = "OpenJDK"
+	case strings.Contains(lowerOutput, "oracle"):
+		version.Vendor = "Oracle"
+	case strings.Contains(lowerOutput, "graalvm"):
+		version.Vendor = "GraalVM"
+	case strings.Contains(lowerOutput, "adoptopenjdk"):
+		version.Vendor = "AdoptOpenJDK"
+	case strings.Contains(lowerOutput, "temurin"):
+		version.Vendor = "Eclipse Temurin"
+	default:
+		version.Vendor = "Unknown"
+	}
+	
+	return version
+}

--- a/tools/default_jar.go
+++ b/tools/default_jar.go
@@ -1,0 +1,226 @@
+package tools
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultJarTool implements JarTool using the system jar command
+type DefaultJarTool struct {
+	jarPath string
+	version *JavaVersion
+}
+
+// NewDefaultJarTool creates a new DefaultJarTool
+func NewDefaultJarTool() *DefaultJarTool {
+	return &DefaultJarTool{}
+}
+
+// Create creates a new JAR file
+func (t *DefaultJarTool) Create(args JarArgs) error {
+	if !t.IsAvailable() {
+		return fmt.Errorf("jar tool not found in PATH")
+	}
+
+	// Build jar command arguments
+	cmdArgs := []string{}
+	
+	// Use create flag with file option
+	// Java 8 uses short form: -cf
+	// Newer versions also support long form: --create --file
+	cmdArgs = append(cmdArgs, "-cf", args.JarFile)
+	
+	// Add date if specified (for reproducible builds)
+	// This is only available in newer JDK versions
+	if args.Date != "" {
+		version, err := t.Version()
+		if err == nil && version.Major >= 11 {
+			cmdArgs = append(cmdArgs, "--date", args.Date)
+		}
+	}
+	
+	// Add main class if specified
+	if args.MainClass != "" {
+		cmdArgs = append(cmdArgs, "--main-class", args.MainClass)
+	}
+	
+	// Handle manifest
+	if args.ManifestFile != "" {
+		cmdArgs = append(cmdArgs, "--manifest", args.ManifestFile)
+	} else if len(args.ClassPath) > 0 {
+		// Create a temporary manifest file with Class-Path
+		manifestContent := "Manifest-Version: 1.0\n"
+		if len(args.ClassPath) > 0 {
+			manifestContent += "Class-Path:"
+			for i, cp := range args.ClassPath {
+				if i > 0 {
+					manifestContent += "\n "
+				} else {
+					manifestContent += " "
+				}
+				manifestContent += cp
+			}
+			manifestContent += "\n"
+		}
+		
+		tmpManifest := filepath.Join(os.TempDir(), fmt.Sprintf("jb-manifest-%d.txt", os.Getpid()))
+		defer os.Remove(tmpManifest)
+		
+		if err := os.WriteFile(tmpManifest, []byte(manifestContent), 0644); err != nil {
+			return fmt.Errorf("failed to write manifest: %w", err)
+		}
+		
+		cmdArgs = append(cmdArgs, "--manifest", tmpManifest)
+	}
+	
+	// Add base directory if specified
+	if args.BaseDir != "" {
+		cmdArgs = append(cmdArgs, "-C", args.BaseDir)
+	}
+	
+	// Add files
+	if len(args.Files) == 0 {
+		// If no files specified, include everything in base directory
+		cmdArgs = append(cmdArgs, ".")
+	} else {
+		cmdArgs = append(cmdArgs, args.Files...)
+	}
+	
+	// Execute jar command
+	cmd := exec.Command(t.jarPath, cmdArgs...)
+	if args.WorkDir != "" {
+		cmd.Dir = args.WorkDir
+	}
+	
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("jar creation failed: %w\nOutput: %s", err, string(output))
+	}
+	
+	return nil
+}
+
+// Extract extracts files from a JAR
+func (t *DefaultJarTool) Extract(jarFile, destDir string) error {
+	if !t.IsAvailable() {
+		return fmt.Errorf("jar tool not found in PATH")
+	}
+	
+	// Ensure destination directory exists
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+	
+	// Extract: jar -xf jarfile
+	cmd := exec.Command(t.jarPath, "-xf", jarFile)
+	cmd.Dir = destDir
+	
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("jar extraction failed: %w\nOutput: %s", err, string(output))
+	}
+	
+	return nil
+}
+
+// List lists the contents of a JAR file
+func (t *DefaultJarTool) List(jarFile string) ([]string, error) {
+	if !t.IsAvailable() {
+		return nil, fmt.Errorf("jar tool not found in PATH")
+	}
+	
+	// List: jar -tf jarfile
+	cmd := exec.Command(t.jarPath, "-tf", jarFile)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list jar contents: %w", err)
+	}
+	
+	// Parse output into file list
+	var files []string
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		file := strings.TrimSpace(scanner.Text())
+		if file != "" {
+			files = append(files, file)
+		}
+	}
+	
+	return files, nil
+}
+
+// Update adds or updates files in an existing JAR
+func (t *DefaultJarTool) Update(jarFile string, files map[string]string) error {
+	if !t.IsAvailable() {
+		return fmt.Errorf("jar tool not found in PATH")
+	}
+	
+	// For each file, we need to update the jar
+	// jar -uf jarfile -C dir file
+	for jarPath, localPath := range files {
+		dir := filepath.Dir(localPath)
+		file := filepath.Base(localPath)
+		
+		cmdArgs := []string{"-uf", jarFile}
+		if dir != "." && dir != "" {
+			cmdArgs = append(cmdArgs, "-C", dir)
+		}
+		cmdArgs = append(cmdArgs, file)
+		
+		cmd := exec.Command(t.jarPath, cmdArgs...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to update jar with %s: %w\nOutput: %s", jarPath, err, string(output))
+		}
+	}
+	
+	return nil
+}
+
+// Version returns the tool version information
+func (t *DefaultJarTool) Version() (JavaVersion, error) {
+	if t.version != nil {
+		return *t.version, nil
+	}
+	
+	if !t.IsAvailable() {
+		return JavaVersion{}, fmt.Errorf("jar tool not found")
+	}
+	
+	// The jar tool doesn't have a direct version flag, but we can use java -version
+	// since they're typically from the same JDK
+	javaPath, err := exec.LookPath("java")
+	if err != nil {
+		return JavaVersion{}, fmt.Errorf("java not found")
+	}
+	
+	cmd := exec.Command(javaPath, "-version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return JavaVersion{}, fmt.Errorf("failed to get java version: %w", err)
+	}
+	
+	version := parseJavaVersion(string(output))
+	t.version = &version
+	return version, nil
+}
+
+// IsAvailable checks if the tool is available on the system
+func (t *DefaultJarTool) IsAvailable() bool {
+	if t.jarPath != "" {
+		return true
+	}
+	
+	// Try to find jar
+	path, err := exec.LookPath("jar")
+	if err != nil {
+		return false
+	}
+	
+	t.jarPath = path
+	return true
+}

--- a/tools/default_runner.go
+++ b/tools/default_runner.go
@@ -1,0 +1,198 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultJavaRunner implements JavaRunner using the system java command
+type DefaultJavaRunner struct {
+	javaPath string
+	version  *JavaVersion
+}
+
+// NewDefaultJavaRunner creates a new DefaultJavaRunner
+func NewDefaultJavaRunner() *DefaultJavaRunner {
+	return &DefaultJavaRunner{}
+}
+
+// Run executes a Java program
+func (r *DefaultJavaRunner) Run(args RunArgs) error {
+	if !r.IsAvailable() {
+		return fmt.Errorf("java not found in PATH")
+	}
+
+	// Build command arguments
+	cmdArgs := []string{}
+	
+	// Add JVM arguments
+	cmdArgs = append(cmdArgs, args.JvmArgs...)
+	
+	// Add classpath if specified
+	if args.ClassPath != "" {
+		cmdArgs = append(cmdArgs, "-cp", args.ClassPath)
+	}
+	
+	// Add main class or jar file
+	if args.JarFile != "" {
+		cmdArgs = append(cmdArgs, "-jar", args.JarFile)
+	} else if args.MainClass != "" {
+		cmdArgs = append(cmdArgs, args.MainClass)
+	} else {
+		return fmt.Errorf("either MainClass or JarFile must be specified")
+	}
+	
+	// Add program arguments
+	cmdArgs = append(cmdArgs, args.ProgramArgs...)
+	
+	// Create command
+	cmd := exec.Command(r.javaPath, cmdArgs...)
+	
+	// Set working directory
+	if args.WorkDir != "" {
+		cmd.Dir = args.WorkDir
+	}
+	
+	// Set environment
+	if len(args.Env) > 0 {
+		cmd.Env = append(os.Environ(), args.Env...)
+	}
+	
+	// Set I/O
+	if args.Stdin != nil {
+		cmd.Stdin = args.Stdin
+	} else {
+		cmd.Stdin = os.Stdin
+	}
+	
+	if args.Stdout != nil {
+		cmd.Stdout = args.Stdout
+	} else {
+		cmd.Stdout = os.Stdout
+	}
+	
+	if args.Stderr != nil {
+		cmd.Stderr = args.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+	
+	// Run the command
+	return cmd.Run()
+}
+
+// RunWithTimeout executes a Java program with a timeout
+func (r *DefaultJavaRunner) RunWithTimeout(args RunArgs, timeout time.Duration) error {
+	if !r.IsAvailable() {
+		return fmt.Errorf("java not found in PATH")
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Build command arguments
+	cmdArgs := []string{}
+	
+	// Add JVM arguments
+	cmdArgs = append(cmdArgs, args.JvmArgs...)
+	
+	// Add classpath if specified
+	if args.ClassPath != "" {
+		cmdArgs = append(cmdArgs, "-cp", args.ClassPath)
+	}
+	
+	// Add main class or jar file
+	if args.JarFile != "" {
+		cmdArgs = append(cmdArgs, "-jar", args.JarFile)
+	} else if args.MainClass != "" {
+		cmdArgs = append(cmdArgs, args.MainClass)
+	} else {
+		return fmt.Errorf("either MainClass or JarFile must be specified")
+	}
+	
+	// Add program arguments
+	cmdArgs = append(cmdArgs, args.ProgramArgs...)
+	
+	// Create command with context
+	cmd := exec.CommandContext(ctx, r.javaPath, cmdArgs...)
+	
+	// Set working directory
+	if args.WorkDir != "" {
+		cmd.Dir = args.WorkDir
+	}
+	
+	// Set environment
+	if len(args.Env) > 0 {
+		cmd.Env = append(os.Environ(), args.Env...)
+	}
+	
+	// Set I/O
+	if args.Stdin != nil {
+		cmd.Stdin = args.Stdin
+	} else {
+		cmd.Stdin = os.Stdin
+	}
+	
+	if args.Stdout != nil {
+		cmd.Stdout = args.Stdout
+	} else {
+		cmd.Stdout = os.Stdout
+	}
+	
+	if args.Stderr != nil {
+		cmd.Stderr = args.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+	
+	// Run the command
+	err := cmd.Run()
+	
+	// Check if the context was cancelled (timeout)
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("java process timed out after %v", timeout)
+	}
+	
+	return err
+}
+
+// Version returns the Java runtime version information
+func (r *DefaultJavaRunner) Version() (JavaVersion, error) {
+	if r.version != nil {
+		return *r.version, nil
+	}
+	
+	if !r.IsAvailable() {
+		return JavaVersion{}, fmt.Errorf("java not found")
+	}
+	
+	cmd := exec.Command(r.javaPath, "-version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return JavaVersion{}, fmt.Errorf("failed to get java version: %w", err)
+	}
+	
+	version := parseJavaVersion(string(output))
+	r.version = &version
+	return version, nil
+}
+
+// IsAvailable checks if Java runtime is available on the system
+func (r *DefaultJavaRunner) IsAvailable() bool {
+	if r.javaPath != "" {
+		return true
+	}
+	
+	// Try to find java
+	path, err := exec.LookPath("java")
+	if err != nil {
+		return false
+	}
+	
+	r.javaPath = path
+	return true
+}

--- a/tools/interfaces.go
+++ b/tools/interfaces.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"io"
+	"time"
+)
+
+// JavaVersion represents a Java version with major, minor, and patch components
+type JavaVersion struct {
+	Major  int
+	Minor  int
+	Patch  int
+	Full   string // Full version string as reported by the tool
+	Vendor string // OpenJDK, Oracle, etc.
+}
+
+// CompileArgs represents arguments for Java compilation
+type CompileArgs struct {
+	SourceFiles   []string
+	ClassPath     string
+	DestDir       string
+	SourceVersion string // e.g., "8", "11", "17"
+	TargetVersion string // e.g., "8", "11", "17"
+	ExtraFlags    []string
+	WorkDir       string // Working directory for the compilation
+}
+
+// CompileResult represents the result of a compilation
+type CompileResult struct {
+	Success      bool
+	ErrorCount   int
+	WarningCount int
+	Errors       []CompileError
+	Warnings     []CompileWarning
+	RawOutput    string // Raw compiler output for debugging
+}
+
+// CompileError represents a compilation error
+type CompileError struct {
+	File    string
+	Line    int
+	Column  int
+	Message string
+	Code    string // Error code if available
+}
+
+// CompileWarning represents a compilation warning
+type CompileWarning struct {
+	File    string
+	Line    int
+	Column  int
+	Message string
+	Code    string // Warning code if available
+}
+
+// JarArgs represents arguments for creating a JAR file
+type JarArgs struct {
+	JarFile      string
+	BaseDir      string   // Directory to change to before adding files
+	Files        []string // Files/directories to include (relative to BaseDir)
+	MainClass    string   // Main class for executable JARs
+	ClassPath    []string // Class-Path entries for manifest
+	ManifestFile string   // Custom manifest file
+	Date         string   // Creation date (for reproducible builds)
+	WorkDir      string   // Working directory
+}
+
+// RunArgs represents arguments for running a Java program
+type RunArgs struct {
+	MainClass   string   // Either main class or -jar jarfile
+	JarFile     string   // JAR file to run (if applicable)
+	ClassPath   string   // Classpath
+	JvmArgs     []string // JVM arguments (e.g., -Xmx512m)
+	ProgramArgs []string // Arguments to pass to the program
+	WorkDir     string   // Working directory
+	Env         []string // Environment variables
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+}
+
+// JavaCompiler is the interface for Java compilation
+type JavaCompiler interface {
+	// Compile compiles Java source files
+	Compile(args CompileArgs) (CompileResult, error)
+	
+	// Version returns the compiler version information
+	Version() (JavaVersion, error)
+	
+	// IsAvailable checks if the compiler is available on the system
+	IsAvailable() bool
+}
+
+// JarTool is the interface for JAR file operations
+type JarTool interface {
+	// Create creates a new JAR file
+	Create(args JarArgs) error
+	
+	// Extract extracts files from a JAR
+	Extract(jarFile, destDir string) error
+	
+	// List lists the contents of a JAR file
+	List(jarFile string) ([]string, error)
+	
+	// Update adds or updates files in an existing JAR
+	Update(jarFile string, files map[string]string) error
+	
+	// Version returns the tool version information
+	Version() (JavaVersion, error)
+	
+	// IsAvailable checks if the tool is available on the system
+	IsAvailable() bool
+}
+
+// JavaRunner is the interface for running Java programs
+type JavaRunner interface {
+	// Run executes a Java program
+	Run(args RunArgs) error
+	
+	// RunWithTimeout executes a Java program with a timeout
+	RunWithTimeout(args RunArgs, timeout time.Duration) error
+	
+	// Version returns the Java runtime version information
+	Version() (JavaVersion, error)
+	
+	// IsAvailable checks if Java runtime is available on the system
+	IsAvailable() bool
+}
+
+// ToolProvider provides access to Java development tools
+type ToolProvider interface {
+	// GetCompiler returns a JavaCompiler instance
+	GetCompiler() JavaCompiler
+	
+	// GetJarTool returns a JarTool instance
+	GetJarTool() JarTool
+	
+	// GetRunner returns a JavaRunner instance
+	GetRunner() JavaRunner
+	
+	// DetectJDK detects and returns information about the available JDK
+	DetectJDK() (*JDKInfo, error)
+}
+
+// JDKInfo represents information about an installed JDK
+type JDKInfo struct {
+	Version  JavaVersion
+	Home     string // JAVA_HOME path
+	Vendor   string
+	Arch     string // Architecture (x64, aarch64, etc.)
+	OS       string // Operating system
+}

--- a/tools/mocks.go
+++ b/tools/mocks.go
@@ -1,0 +1,283 @@
+package tools
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// MockJavaCompiler is a mock implementation of JavaCompiler for testing
+type MockJavaCompiler struct {
+	CompileFunc     func(args CompileArgs) (CompileResult, error)
+	VersionFunc     func() (JavaVersion, error)
+	IsAvailableFunc func() bool
+	
+	// Record of calls
+	CompileCalls []CompileArgs
+	VersionCalls int
+	IsAvailableCalls int
+}
+
+func (m *MockJavaCompiler) Compile(args CompileArgs) (CompileResult, error) {
+	m.CompileCalls = append(m.CompileCalls, args)
+	if m.CompileFunc != nil {
+		return m.CompileFunc(args)
+	}
+	return CompileResult{Success: true}, nil
+}
+
+func (m *MockJavaCompiler) Version() (JavaVersion, error) {
+	m.VersionCalls++
+	if m.VersionFunc != nil {
+		return m.VersionFunc()
+	}
+	return JavaVersion{Major: 17, Minor: 0, Patch: 1, Vendor: "Mock"}, nil
+}
+
+func (m *MockJavaCompiler) IsAvailable() bool {
+	m.IsAvailableCalls++
+	if m.IsAvailableFunc != nil {
+		return m.IsAvailableFunc()
+	}
+	return true
+}
+
+// MockJarTool is a mock implementation of JarTool for testing
+type MockJarTool struct {
+	CreateFunc      func(args JarArgs) error
+	ExtractFunc     func(jarFile, destDir string) error
+	ListFunc        func(jarFile string) ([]string, error)
+	UpdateFunc      func(jarFile string, files map[string]string) error
+	VersionFunc     func() (JavaVersion, error)
+	IsAvailableFunc func() bool
+	
+	// Record of calls
+	CreateCalls      []JarArgs
+	ExtractCalls     []struct{ JarFile, DestDir string }
+	ListCalls        []string
+	UpdateCalls      []struct{ JarFile string; Files map[string]string }
+	VersionCalls     int
+	IsAvailableCalls int
+}
+
+func (m *MockJarTool) Create(args JarArgs) error {
+	m.CreateCalls = append(m.CreateCalls, args)
+	if m.CreateFunc != nil {
+		return m.CreateFunc(args)
+	}
+	return nil
+}
+
+func (m *MockJarTool) Extract(jarFile, destDir string) error {
+	m.ExtractCalls = append(m.ExtractCalls, struct{ JarFile, DestDir string }{jarFile, destDir})
+	if m.ExtractFunc != nil {
+		return m.ExtractFunc(jarFile, destDir)
+	}
+	return nil
+}
+
+func (m *MockJarTool) List(jarFile string) ([]string, error) {
+	m.ListCalls = append(m.ListCalls, jarFile)
+	if m.ListFunc != nil {
+		return m.ListFunc(jarFile)
+	}
+	return []string{"META-INF/", "META-INF/MANIFEST.MF", "com/", "com/example/", "com/example/Main.class"}, nil
+}
+
+func (m *MockJarTool) Update(jarFile string, files map[string]string) error {
+	m.UpdateCalls = append(m.UpdateCalls, struct{ JarFile string; Files map[string]string }{jarFile, files})
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(jarFile, files)
+	}
+	return nil
+}
+
+func (m *MockJarTool) Version() (JavaVersion, error) {
+	m.VersionCalls++
+	if m.VersionFunc != nil {
+		return m.VersionFunc()
+	}
+	return JavaVersion{Major: 17, Minor: 0, Patch: 1, Vendor: "Mock"}, nil
+}
+
+func (m *MockJarTool) IsAvailable() bool {
+	m.IsAvailableCalls++
+	if m.IsAvailableFunc != nil {
+		return m.IsAvailableFunc()
+	}
+	return true
+}
+
+// MockJavaRunner is a mock implementation of JavaRunner for testing
+type MockJavaRunner struct {
+	RunFunc             func(args RunArgs) error
+	RunWithTimeoutFunc  func(args RunArgs, timeout time.Duration) error
+	VersionFunc         func() (JavaVersion, error)
+	IsAvailableFunc     func() bool
+	
+	// Record of calls
+	RunCalls            []RunArgs
+	RunWithTimeoutCalls []struct {
+		Args    RunArgs
+		Timeout time.Duration
+	}
+	VersionCalls     int
+	IsAvailableCalls int
+}
+
+func (m *MockJavaRunner) Run(args RunArgs) error {
+	m.RunCalls = append(m.RunCalls, args)
+	if m.RunFunc != nil {
+		return m.RunFunc(args)
+	}
+	return nil
+}
+
+func (m *MockJavaRunner) RunWithTimeout(args RunArgs, timeout time.Duration) error {
+	m.RunWithTimeoutCalls = append(m.RunWithTimeoutCalls, struct {
+		Args    RunArgs
+		Timeout time.Duration
+	}{args, timeout})
+	if m.RunWithTimeoutFunc != nil {
+		return m.RunWithTimeoutFunc(args, timeout)
+	}
+	return nil
+}
+
+func (m *MockJavaRunner) Version() (JavaVersion, error) {
+	m.VersionCalls++
+	if m.VersionFunc != nil {
+		return m.VersionFunc()
+	}
+	return JavaVersion{Major: 17, Minor: 0, Patch: 1, Vendor: "Mock"}, nil
+}
+
+func (m *MockJavaRunner) IsAvailable() bool {
+	m.IsAvailableCalls++
+	if m.IsAvailableFunc != nil {
+		return m.IsAvailableFunc()
+	}
+	return true
+}
+
+// MockToolProvider is a mock implementation of ToolProvider for testing
+type MockToolProvider struct {
+	Compiler  JavaCompiler
+	JarTool   JarTool
+	Runner    JavaRunner
+	JDKInfo   *JDKInfo
+	JDKError  error
+}
+
+func (m *MockToolProvider) GetCompiler() JavaCompiler {
+	if m.Compiler != nil {
+		return m.Compiler
+	}
+	return &MockJavaCompiler{}
+}
+
+func (m *MockToolProvider) GetJarTool() JarTool {
+	if m.JarTool != nil {
+		return m.JarTool
+	}
+	return &MockJarTool{}
+}
+
+func (m *MockToolProvider) GetRunner() JavaRunner {
+	if m.Runner != nil {
+		return m.Runner
+	}
+	return &MockJavaRunner{}
+}
+
+func (m *MockToolProvider) DetectJDK() (*JDKInfo, error) {
+	if m.JDKError != nil {
+		return nil, m.JDKError
+	}
+	if m.JDKInfo != nil {
+		return m.JDKInfo, nil
+	}
+	return &JDKInfo{
+		Version: JavaVersion{Major: 17, Minor: 0, Patch: 1, Vendor: "Mock"},
+		Home:    "/mock/java/home",
+		Vendor:  "Mock",
+		Arch:    "x64",
+		OS:      "mock",
+	}, nil
+}
+
+// Helper functions for creating pre-configured mocks
+
+// NewSuccessfulCompilerMock creates a mock compiler that always succeeds
+func NewSuccessfulCompilerMock() *MockJavaCompiler {
+	return &MockJavaCompiler{
+		CompileFunc: func(args CompileArgs) (CompileResult, error) {
+			return CompileResult{
+				Success:      true,
+				ErrorCount:   0,
+				WarningCount: 0,
+			}, nil
+		},
+	}
+}
+
+// NewFailingCompilerMock creates a mock compiler that always fails with the given errors
+func NewFailingCompilerMock(errors []CompileError) *MockJavaCompiler {
+	return &MockJavaCompiler{
+		CompileFunc: func(args CompileArgs) (CompileResult, error) {
+			return CompileResult{
+				Success:    false,
+				ErrorCount: len(errors),
+				Errors:     errors,
+			}, nil
+		},
+	}
+}
+
+// NewSuccessfulJarToolMock creates a mock jar tool that always succeeds
+func NewSuccessfulJarToolMock() *MockJarTool {
+	return &MockJarTool{}
+}
+
+// NewSuccessfulRunnerMock creates a mock runner that always succeeds
+func NewSuccessfulRunnerMock() *MockJavaRunner {
+	return &MockJavaRunner{}
+}
+
+// CaptureWriter is a simple io.Writer that captures written data
+type CaptureWriter struct {
+	Data []byte
+}
+
+func (w *CaptureWriter) Write(p []byte) (n int, err error) {
+	w.Data = append(w.Data, p...)
+	return len(p), nil
+}
+
+func (w *CaptureWriter) String() string {
+	return string(w.Data)
+}
+
+// ErrorWriter is an io.Writer that always returns an error
+type ErrorWriter struct {
+	Err error
+}
+
+func (w *ErrorWriter) Write(p []byte) (n int, err error) {
+	if w.Err != nil {
+		return 0, w.Err
+	}
+	return 0, fmt.Errorf("write error")
+}
+
+// ErrorReader is an io.Reader that always returns an error
+type ErrorReader struct {
+	Err error
+}
+
+func (r *ErrorReader) Read(p []byte) (n int, err error) {
+	if r.Err != nil {
+		return 0, r.Err
+	}
+	return 0, io.EOF
+}

--- a/tools/provider.go
+++ b/tools/provider.go
@@ -1,0 +1,263 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// DefaultToolProvider provides access to system Java development tools
+type DefaultToolProvider struct {
+	compiler JavaCompiler
+	jarTool  JarTool
+	runner   JavaRunner
+	jdkInfo  *JDKInfo
+}
+
+// NewDefaultToolProvider creates a new DefaultToolProvider
+func NewDefaultToolProvider() *DefaultToolProvider {
+	return &DefaultToolProvider{}
+}
+
+// GetCompiler returns a JavaCompiler instance
+func (p *DefaultToolProvider) GetCompiler() JavaCompiler {
+	if p.compiler == nil {
+		p.compiler = NewDefaultJavaCompiler()
+	}
+	return p.compiler
+}
+
+// GetJarTool returns a JarTool instance
+func (p *DefaultToolProvider) GetJarTool() JarTool {
+	if p.jarTool == nil {
+		p.jarTool = NewDefaultJarTool()
+	}
+	return p.jarTool
+}
+
+// GetRunner returns a JavaRunner instance
+func (p *DefaultToolProvider) GetRunner() JavaRunner {
+	if p.runner == nil {
+		p.runner = NewDefaultJavaRunner()
+	}
+	return p.runner
+}
+
+// DetectJDK detects and returns information about the available JDK
+func (p *DefaultToolProvider) DetectJDK() (*JDKInfo, error) {
+	if p.jdkInfo != nil {
+		return p.jdkInfo, nil
+	}
+	
+	info := &JDKInfo{
+		OS:   runtime.GOOS,
+		Arch: runtime.GOARCH,
+	}
+	
+	// First, check JAVA_HOME environment variable
+	javaHome := os.Getenv("JAVA_HOME")
+	if javaHome != "" {
+		// Verify it's a valid JDK home
+		javacPath := filepath.Join(javaHome, "bin", "javac")
+		if runtime.GOOS == "windows" {
+			javacPath += ".exe"
+		}
+		
+		if _, err := os.Stat(javacPath); err == nil {
+			info.Home = javaHome
+		}
+	}
+	
+	// If no valid JAVA_HOME, try to find JDK from javac in PATH
+	if info.Home == "" {
+		javacPath, err := exec.LookPath("javac")
+		if err != nil {
+			return nil, fmt.Errorf("JDK not found: no JAVA_HOME set and javac not in PATH")
+		}
+		
+		// Try to determine JAVA_HOME from javac path
+		// javac is typically at $JAVA_HOME/bin/javac
+		binDir := filepath.Dir(javacPath)
+		possibleHome := filepath.Dir(binDir)
+		
+		// Verify this looks like a JDK home
+		if isValidJDKHome(possibleHome) {
+			info.Home = possibleHome
+		}
+	}
+	
+	// Get version information
+	runner := p.GetRunner()
+	version, err := runner.Version()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Java version: %w", err)
+	}
+	
+	info.Version = version
+	info.Vendor = version.Vendor
+	
+	p.jdkInfo = info
+	return info, nil
+}
+
+// isValidJDKHome checks if a directory looks like a valid JDK home
+func isValidJDKHome(path string) bool {
+	// Check for typical JDK directories and files
+	requiredPaths := []string{
+		filepath.Join(path, "bin", "javac"),
+		filepath.Join(path, "bin", "java"),
+		filepath.Join(path, "bin", "jar"),
+	}
+	
+	if runtime.GOOS == "windows" {
+		for i, p := range requiredPaths {
+			requiredPaths[i] = p + ".exe"
+		}
+	}
+	
+	for _, reqPath := range requiredPaths {
+		if _, err := os.Stat(reqPath); err != nil {
+			return false
+		}
+	}
+	
+	// Check for lib directory (contains tools.jar in older JDKs or modules in newer ones)
+	libPath := filepath.Join(path, "lib")
+	if _, err := os.Stat(libPath); err != nil {
+		return false
+	}
+	
+	return true
+}
+
+// Global default provider instance
+var defaultProvider ToolProvider = NewDefaultToolProvider()
+
+// GetDefaultToolProvider returns the global default tool provider
+func GetDefaultToolProvider() ToolProvider {
+	return defaultProvider
+}
+
+// SetDefaultToolProvider sets the global default tool provider (useful for testing)
+func SetDefaultToolProvider(provider ToolProvider) {
+	defaultProvider = provider
+}
+
+// Helper functions for common version comparisons
+
+// IsJava8OrLater returns true if the version is Java 8 or later
+func (v JavaVersion) IsJava8OrLater() bool {
+	return v.Major >= 8
+}
+
+// IsJava11OrLater returns true if the version is Java 11 or later
+func (v JavaVersion) IsJava11OrLater() bool {
+	return v.Major >= 11
+}
+
+// IsJava17OrLater returns true if the version is Java 17 or later
+func (v JavaVersion) IsJava17OrLater() bool {
+	return v.Major >= 17
+}
+
+// IsJava21OrLater returns true if the version is Java 21 or later
+func (v JavaVersion) IsJava21OrLater() bool {
+	return v.Major >= 21
+}
+
+// String returns a string representation of the version
+func (v JavaVersion) String() string {
+	if v.Full != "" {
+		return v.Full
+	}
+	if v.Patch > 0 {
+		return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	}
+	if v.Minor > 0 {
+		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	}
+	return fmt.Sprintf("%d", v.Major)
+}
+
+// CompareVersions compares two Java versions
+// Returns -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+func CompareVersions(v1, v2 JavaVersion) int {
+	if v1.Major != v2.Major {
+		if v1.Major < v2.Major {
+			return -1
+		}
+		return 1
+	}
+	
+	if v1.Minor != v2.Minor {
+		if v1.Minor < v2.Minor {
+			return -1
+		}
+		return 1
+	}
+	
+	if v1.Patch != v2.Patch {
+		if v1.Patch < v2.Patch {
+			return -1
+		}
+		return 1
+	}
+	
+	return 0
+}
+
+// Platform-specific helpers
+
+// GetJavaExecutable returns the platform-specific java executable name
+func GetJavaExecutable() string {
+	if runtime.GOOS == "windows" {
+		return "java.exe"
+	}
+	return "java"
+}
+
+// GetJavacExecutable returns the platform-specific javac executable name
+func GetJavacExecutable() string {
+	if runtime.GOOS == "windows" {
+		return "javac.exe"
+	}
+	return "javac"
+}
+
+// GetJarExecutable returns the platform-specific jar executable name
+func GetJarExecutable() string {
+	if runtime.GOOS == "windows" {
+		return "jar.exe"
+	}
+	return "jar"
+}
+
+// NormalizePath normalizes a file path for the current platform
+func NormalizePath(path string) string {
+	// Convert forward slashes to the platform separator
+	path = filepath.FromSlash(path)
+	
+	// Clean the path
+	path = filepath.Clean(path)
+	
+	return path
+}
+
+// JoinClassPath joins multiple classpath entries with the platform-specific separator
+func JoinClassPath(paths ...string) string {
+	separator := ":"
+	if runtime.GOOS == "windows" {
+		separator = ";"
+	}
+	
+	// Normalize all paths
+	normalizedPaths := make([]string, len(paths))
+	for i, p := range paths {
+		normalizedPaths[i] = NormalizePath(p)
+	}
+	
+	return strings.Join(normalizedPaths, separator)
+}


### PR DESCRIPTION
## Summary
This PR implements a comprehensive abstraction layer for external Java tools (javac, jar, java) to improve testability and cross-platform support.

## Changes
### New `tools` Package
- **interfaces.go**: Defines interfaces for JavaCompiler, JarTool, JavaRunner, and ToolProvider
- **default_compiler.go**: Default javac implementation with error parsing
- **default_jar.go**: Default jar tool implementation
- **default_runner.go**: Default java runner implementation
- **provider.go**: Tool provider with JDK detection and platform helpers
- **mocks.go**: Mock implementations for unit testing

### Updated Java Builder
- Replaced direct `exec.Command` calls with tool abstractions
- Improved error handling with structured compilation results
- Better error messages with parsed warnings and errors
- Removed unused imports

### Documentation
- Added strategic testing plan in `docs/plan-claude.md`
- Marked abstraction layer task as completed

## Benefits
- **Testability**: Can now write unit tests with mocks instead of requiring real JDK
- **Cross-platform**: Platform differences handled in one place
- **Better errors**: Compilation errors are parsed and presented clearly
- **Extensibility**: Easy to add support for different tools or versions
- **Version detection**: Can adapt behavior based on JDK version

## Testing
- All existing tests pass
- Build works correctly
- Ready for comprehensive unit tests using the new mocks

This completes the first major task from the testing strategy plan and provides the foundation for improved testing coverage.