### PR TITLE
Add dynamic version support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,10 @@ jobs:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
       run: |
-        go build -v -o ${{ matrix.binary_name }} -ldflags="-s -w"
+        VERSION=${GITHUB_REF#refs/tags/v}
+        COMMIT=$(git rev-parse --short HEAD)
+        DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        go build -v -o ${{ matrix.binary_name }} -ldflags="-s -w -X github.com/jsando/jb/version.Version=$VERSION -X github.com/jsando/jb/version.Commit=$COMMIT -X github.com/jsando/jb/version.Date=$DATE"
     
     - name: Upload to release
       uses: svenstaro/upload-release-action@v2

--- a/builder/buildlog.go
+++ b/builder/buildlog.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"fmt"
 	"github.com/jsando/jb/project"
+	"github.com/jsando/jb/version"
 	"github.com/pterm/pterm"
 	"os"
 	"time"
@@ -47,7 +48,7 @@ func NewBuildLog() *buildLog {
 
 func (b *buildLog) BuildStart() {
 	b.buildStartTime = time.Now()
-	fmt.Println("JB 1.0.0 - Build Started")
+	fmt.Printf("JB %s - Build Started\n", version.Version)
 }
 
 func (b *buildLog) BuildFinish() {

--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"github.com/jsando/jb/builder"
+	"github.com/jsando/jb/version"
 	"github.com/pterm/pterm"
 	"os"
 	"slices"
 )
 
-const USAGE = `jb (1.0.0) - The Easier Java Build Tool'
+const USAGE = `jb - The Easier Java Build Tool
 Usage: jb [command] [command-options] [arguments]
 
 Execute a command.
@@ -22,12 +23,20 @@ Commands:
   publish  Publish a module to the local maven repository or a remote repository.
   run      Build and run an ExecutableJar module.
   test     Run tests for a module.
+  version  Show version information.
 
 Run 'jb [command] --help' for more information on a command.`
 
 func usage(exitCode int) {
 	fmt.Println(USAGE)
 	os.Exit(exitCode)
+}
+
+func versionCommand() {
+	fmt.Printf("jb version %s\n", version.Version)
+	fmt.Printf(" commit: %s\n", version.Commit)
+	fmt.Printf(" built: %s\n", version.Date)
+	os.Exit(0)
 }
 
 func main() {
@@ -51,6 +60,8 @@ func main() {
 		runCommand(os.Args[2:])
 	case "test":
 		testCommand(os.Args[2:])
+	case "version", "-v", "--version":
+		versionCommand()
 	default:
 		fmt.Printf("jb: unknown command %s\n", command)
 		usage(1)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// Build time variables set via -ldflags
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)


### PR DESCRIPTION
## Summary
- Add version command to show version, commit, and build date
- Support -v and --version flags 
- Create version package with build-time variables
- Update release workflow to inject version info via ldflags

## Implementation
Following the pattern used in jsando/mpu:
- Version variables can be set at build time using ldflags
- Default to 'dev' version for local development
- Release builds automatically extract version from git tag

## Testing
```bash
$ go run . version
jb version dev
 commit: none
 built: unknown

$ ./jb-test version  # built with ldflags
jb version 0.2.0-test
 commit: 78b9ac2
 built: 2025-06-29T23:08:36Z
```